### PR TITLE
Rename Error -> CryptoError to fix kotlin binding generation

### DIFF
--- a/lightspark-crypto-kotlin/uniffi/lightspark_crypto/lightspark_crypto.kt
+++ b/lightspark-crypto-kotlin/uniffi/lightspark_crypto/lightspark_crypto.kt
@@ -46,7 +46,7 @@ open class RustBuffer : Structure() {
     companion object {
         internal fun alloc(size: Int = 0) =
             rustCall { status ->
-                _UniFFILib.INSTANCE.ffi_lightspark_crypto_2f27_rustbuffer_alloc(size, status).also {
+                _UniFFILib.INSTANCE.ffi_lightspark_crypto_5548_rustbuffer_alloc(size, status).also {
                     if (it.data == null) {
                         throw RuntimeException("RustBuffer.alloc() returned null data pointer (size=$size)")
                     }
@@ -55,7 +55,7 @@ open class RustBuffer : Structure() {
 
         internal fun free(buf: RustBuffer.ByValue) =
             rustCall { status ->
-                _UniFFILib.INSTANCE.ffi_lightspark_crypto_2f27_rustbuffer_free(buf, status)
+                _UniFFILib.INSTANCE.ffi_lightspark_crypto_5548_rustbuffer_free(buf, status)
             }
     }
 
@@ -273,110 +273,110 @@ internal interface _UniFFILib : Library {
         }
     }
 
-    fun ffi_lightspark_crypto_2f27_Mnemonic_object_free(
+    fun ffi_lightspark_crypto_5548_Mnemonic_object_free(
         `ptr`: Pointer,
         _uniffi_out_err: RustCallStatus,
     ): Unit
 
-    fun lightspark_crypto_2f27_Mnemonic_random(_uniffi_out_err: RustCallStatus): Pointer
+    fun lightspark_crypto_5548_Mnemonic_random(_uniffi_out_err: RustCallStatus): Pointer
 
-    fun lightspark_crypto_2f27_Mnemonic_from_entropy(
+    fun lightspark_crypto_5548_Mnemonic_from_entropy(
         `entropy`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): Pointer
 
-    fun lightspark_crypto_2f27_Mnemonic_from_phrase(
+    fun lightspark_crypto_5548_Mnemonic_from_phrase(
         `phrase`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): Pointer
 
-    fun lightspark_crypto_2f27_Mnemonic_as_string(
+    fun lightspark_crypto_5548_Mnemonic_as_string(
         `ptr`: Pointer,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun ffi_lightspark_crypto_2f27_Seed_object_free(
+    fun ffi_lightspark_crypto_5548_Seed_object_free(
         `ptr`: Pointer,
         _uniffi_out_err: RustCallStatus,
     ): Unit
 
-    fun lightspark_crypto_2f27_Seed_new(
+    fun lightspark_crypto_5548_Seed_new(
         `seed`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): Pointer
 
-    fun lightspark_crypto_2f27_Seed_from_mnemonic(
+    fun lightspark_crypto_5548_Seed_from_mnemonic(
         `mnemonic`: Pointer,
         _uniffi_out_err: RustCallStatus,
     ): Pointer
 
-    fun lightspark_crypto_2f27_Seed_as_bytes(
+    fun lightspark_crypto_5548_Seed_as_bytes(
         `ptr`: Pointer,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun ffi_lightspark_crypto_2f27_InvoiceSignature_object_free(
+    fun ffi_lightspark_crypto_5548_InvoiceSignature_object_free(
         `ptr`: Pointer,
         _uniffi_out_err: RustCallStatus,
     ): Unit
 
-    fun lightspark_crypto_2f27_InvoiceSignature_get_recovery_id(
+    fun lightspark_crypto_5548_InvoiceSignature_get_recovery_id(
         `ptr`: Pointer,
         _uniffi_out_err: RustCallStatus,
     ): Int
 
-    fun lightspark_crypto_2f27_InvoiceSignature_get_signature(
+    fun lightspark_crypto_5548_InvoiceSignature_get_signature(
         `ptr`: Pointer,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun ffi_lightspark_crypto_2f27_LightsparkSigner_object_free(
+    fun ffi_lightspark_crypto_5548_LightsparkSigner_object_free(
         `ptr`: Pointer,
         _uniffi_out_err: RustCallStatus,
     ): Unit
 
-    fun lightspark_crypto_2f27_LightsparkSigner_new(
+    fun lightspark_crypto_5548_LightsparkSigner_new(
         `seed`: Pointer,
         `network`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): Pointer
 
-    fun lightspark_crypto_2f27_LightsparkSigner_from_bytes(
+    fun lightspark_crypto_5548_LightsparkSigner_from_bytes(
         `seed`: RustBuffer.ByValue,
         `network`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): Pointer
 
-    fun lightspark_crypto_2f27_LightsparkSigner_get_master_public_key(
+    fun lightspark_crypto_5548_LightsparkSigner_get_master_public_key(
         `ptr`: Pointer,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun lightspark_crypto_2f27_LightsparkSigner_derive_public_key(
+    fun lightspark_crypto_5548_LightsparkSigner_derive_public_key(
         `ptr`: Pointer,
         `derivationPath`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun lightspark_crypto_2f27_LightsparkSigner_ecdh(
+    fun lightspark_crypto_5548_LightsparkSigner_ecdh(
         `ptr`: Pointer,
         `publicKey`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun lightspark_crypto_2f27_LightsparkSigner_sign_invoice(
+    fun lightspark_crypto_5548_LightsparkSigner_sign_invoice(
         `ptr`: Pointer,
         `unsignedInvoice`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): Pointer
 
-    fun lightspark_crypto_2f27_LightsparkSigner_sign_invoice_hash(
+    fun lightspark_crypto_5548_LightsparkSigner_sign_invoice_hash(
         `ptr`: Pointer,
         `unsignedInvoice`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): Pointer
 
-    fun lightspark_crypto_2f27_LightsparkSigner_derive_key_and_sign(
+    fun lightspark_crypto_5548_LightsparkSigner_derive_key_and_sign(
         `ptr`: Pointer,
         `message`: RustBuffer.ByValue,
         `derivationPath`: RustBuffer.ByValue,
@@ -386,78 +386,78 @@ internal interface _UniFFILib : Library {
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun lightspark_crypto_2f27_LightsparkSigner_get_per_commitment_point(
+    fun lightspark_crypto_5548_LightsparkSigner_get_per_commitment_point(
         `ptr`: Pointer,
         `derivationPath`: RustBuffer.ByValue,
         `perCommitmentPointIdx`: Long,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun lightspark_crypto_2f27_LightsparkSigner_release_per_commitment_secret(
+    fun lightspark_crypto_5548_LightsparkSigner_release_per_commitment_secret(
         `ptr`: Pointer,
         `derivationPath`: RustBuffer.ByValue,
         `perCommitmentPointIdx`: Long,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun lightspark_crypto_2f27_LightsparkSigner_generate_preimage_nonce(
+    fun lightspark_crypto_5548_LightsparkSigner_generate_preimage_nonce(
         `ptr`: Pointer,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun lightspark_crypto_2f27_LightsparkSigner_generate_preimage(
-        `ptr`: Pointer,
-        `nonce`: RustBuffer.ByValue,
-        _uniffi_out_err: RustCallStatus,
-    ): RustBuffer.ByValue
-
-    fun lightspark_crypto_2f27_LightsparkSigner_generate_preimage_hash(
+    fun lightspark_crypto_5548_LightsparkSigner_generate_preimage(
         `ptr`: Pointer,
         `nonce`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun lightspark_crypto_2f27_sign_ecdsa(
+    fun lightspark_crypto_5548_LightsparkSigner_generate_preimage_hash(
+        `ptr`: Pointer,
+        `nonce`: RustBuffer.ByValue,
+        _uniffi_out_err: RustCallStatus,
+    ): RustBuffer.ByValue
+
+    fun lightspark_crypto_5548_sign_ecdsa(
         `msg`: RustBuffer.ByValue,
         `privateKeyBytes`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun lightspark_crypto_2f27_verify_ecdsa(
+    fun lightspark_crypto_5548_verify_ecdsa(
         `msg`: RustBuffer.ByValue,
         `signatureBytes`: RustBuffer.ByValue,
         `publicKeyBytes`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): Byte
 
-    fun lightspark_crypto_2f27_encrypt_ecies(
+    fun lightspark_crypto_5548_encrypt_ecies(
         `msg`: RustBuffer.ByValue,
         `publicKeyBytes`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun lightspark_crypto_2f27_decrypt_ecies(
+    fun lightspark_crypto_5548_decrypt_ecies(
         `cipherText`: RustBuffer.ByValue,
         `privateKeyBytes`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun ffi_lightspark_crypto_2f27_rustbuffer_alloc(
+    fun ffi_lightspark_crypto_5548_rustbuffer_alloc(
         `size`: Int,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun ffi_lightspark_crypto_2f27_rustbuffer_from_bytes(
+    fun ffi_lightspark_crypto_5548_rustbuffer_from_bytes(
         `bytes`: ForeignBytes.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): RustBuffer.ByValue
 
-    fun ffi_lightspark_crypto_2f27_rustbuffer_free(
+    fun ffi_lightspark_crypto_5548_rustbuffer_free(
         `buf`: RustBuffer.ByValue,
         _uniffi_out_err: RustCallStatus,
     ): Unit
 
-    fun ffi_lightspark_crypto_2f27_rustbuffer_reserve(
+    fun ffi_lightspark_crypto_5548_rustbuffer_reserve(
         `buf`: RustBuffer.ByValue,
         `additional`: Int,
         _uniffi_out_err: RustCallStatus,
@@ -787,14 +787,14 @@ class InvoiceSignature(
      */
     protected override fun freeRustArcPtr() {
         rustCall { status ->
-            _UniFFILib.INSTANCE.ffi_lightspark_crypto_2f27_InvoiceSignature_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_lightspark_crypto_5548_InvoiceSignature_object_free(this.pointer, status)
         }
     }
 
     override fun `getRecoveryId`(): Int =
         callWithPointer {
             rustCall { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_InvoiceSignature_get_recovery_id(it, _status)
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_InvoiceSignature_get_recovery_id(it, _status)
             }
         }.let {
             FfiConverterInt.lift(it)
@@ -803,7 +803,7 @@ class InvoiceSignature(
     override fun `getSignature`(): List<UByte> =
         callWithPointer {
             rustCall { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_InvoiceSignature_get_signature(it, _status)
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_InvoiceSignature_get_signature(it, _status)
             }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -887,7 +887,7 @@ class LightsparkSigner(
     constructor(`seed`: Seed, `network`: Network) :
         this(
             rustCallWithError(LightsparkSignerException) { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_new(
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_new(
                     FfiConverterTypeSeed.lower(`seed`),
                     FfiConverterTypeNetwork.lower(`network`),
                     _status,
@@ -905,7 +905,7 @@ class LightsparkSigner(
      */
     protected override fun freeRustArcPtr() {
         rustCall { status ->
-            _UniFFILib.INSTANCE.ffi_lightspark_crypto_2f27_LightsparkSigner_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_lightspark_crypto_5548_LightsparkSigner_object_free(this.pointer, status)
         }
     }
 
@@ -915,7 +915,7 @@ class LightsparkSigner(
     override fun `getMasterPublicKey`(): String =
         callWithPointer {
             rustCallWithError(LightsparkSignerException) { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_get_master_public_key(it, _status)
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_get_master_public_key(it, _status)
             }
         }.let {
             FfiConverterString.lift(it)
@@ -927,7 +927,7 @@ class LightsparkSigner(
     override fun `derivePublicKey`(`derivationPath`: String): String =
         callWithPointer {
             rustCallWithError(LightsparkSignerException) { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_derive_public_key(
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_derive_public_key(
                     it,
                     FfiConverterString.lower(`derivationPath`),
                     _status,
@@ -943,7 +943,7 @@ class LightsparkSigner(
     override fun `ecdh`(`publicKey`: List<UByte>): List<UByte> =
         callWithPointer {
             rustCallWithError(LightsparkSignerException) { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_ecdh(it, FfiConverterSequenceUByte.lower(`publicKey`), _status)
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_ecdh(it, FfiConverterSequenceUByte.lower(`publicKey`), _status)
             }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -955,7 +955,7 @@ class LightsparkSigner(
     override fun `signInvoice`(`unsignedInvoice`: String): InvoiceSignature =
         callWithPointer {
             rustCallWithError(LightsparkSignerException) { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_sign_invoice(
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_sign_invoice(
                     it,
                     FfiConverterString.lower(`unsignedInvoice`),
                     _status,
@@ -971,7 +971,7 @@ class LightsparkSigner(
     override fun `signInvoiceHash`(`unsignedInvoice`: List<UByte>): InvoiceSignature =
         callWithPointer {
             rustCallWithError(LightsparkSignerException) { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_sign_invoice_hash(
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_sign_invoice_hash(
                     it,
                     FfiConverterSequenceUByte.lower(`unsignedInvoice`),
                     _status,
@@ -993,7 +993,7 @@ class LightsparkSigner(
     ): List<UByte> =
         callWithPointer {
             rustCallWithError(LightsparkSignerException) { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_derive_key_and_sign(
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_derive_key_and_sign(
                     it,
                     FfiConverterSequenceUByte.lower(`message`),
                     FfiConverterString.lower(`derivationPath`),
@@ -1016,7 +1016,7 @@ class LightsparkSigner(
     ): List<UByte> =
         callWithPointer {
             rustCallWithError(LightsparkSignerException) { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_get_per_commitment_point(
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_get_per_commitment_point(
                     it,
                     FfiConverterString.lower(`derivationPath`),
                     FfiConverterULong.lower(`perCommitmentPointIdx`),
@@ -1036,7 +1036,7 @@ class LightsparkSigner(
     ): List<UByte> =
         callWithPointer {
             rustCallWithError(LightsparkSignerException) { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_release_per_commitment_secret(
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_release_per_commitment_secret(
                     it,
                     FfiConverterString.lower(`derivationPath`),
                     FfiConverterULong.lower(`perCommitmentPointIdx`),
@@ -1050,7 +1050,7 @@ class LightsparkSigner(
     override fun `generatePreimageNonce`(): List<UByte> =
         callWithPointer {
             rustCall { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_generate_preimage_nonce(it, _status)
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_generate_preimage_nonce(it, _status)
             }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1062,7 +1062,7 @@ class LightsparkSigner(
     override fun `generatePreimage`(`nonce`: List<UByte>): List<UByte> =
         callWithPointer {
             rustCallWithError(LightsparkSignerException) { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_generate_preimage(
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_generate_preimage(
                     it,
                     FfiConverterSequenceUByte.lower(`nonce`),
                     _status,
@@ -1078,7 +1078,7 @@ class LightsparkSigner(
     override fun `generatePreimageHash`(`nonce`: List<UByte>): List<UByte> =
         callWithPointer {
             rustCallWithError(LightsparkSignerException) { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_generate_preimage_hash(
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_generate_preimage_hash(
                     it,
                     FfiConverterSequenceUByte.lower(`nonce`),
                     _status,
@@ -1095,7 +1095,7 @@ class LightsparkSigner(
         ): LightsparkSigner =
             LightsparkSigner(
                 rustCallWithError(LightsparkSignerException) { _status ->
-                    _UniFFILib.INSTANCE.lightspark_crypto_2f27_LightsparkSigner_from_bytes(
+                    _UniFFILib.INSTANCE.lightspark_crypto_5548_LightsparkSigner_from_bytes(
                         FfiConverterSequenceUByte.lower(`seed`),
                         FfiConverterTypeNetwork.lower(`network`),
                         _status,
@@ -1147,14 +1147,14 @@ class Mnemonic(
      */
     protected override fun freeRustArcPtr() {
         rustCall { status ->
-            _UniFFILib.INSTANCE.ffi_lightspark_crypto_2f27_Mnemonic_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_lightspark_crypto_5548_Mnemonic_object_free(this.pointer, status)
         }
     }
 
     override fun `asString`(): String =
         callWithPointer {
             rustCall { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_Mnemonic_as_string(it, _status)
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_Mnemonic_as_string(it, _status)
             }
         }.let {
             FfiConverterString.lift(it)
@@ -1164,21 +1164,21 @@ class Mnemonic(
         fun `random`(): Mnemonic =
             Mnemonic(
                 rustCallWithError(LightsparkSignerException) { _status ->
-                    _UniFFILib.INSTANCE.lightspark_crypto_2f27_Mnemonic_random(_status)
+                    _UniFFILib.INSTANCE.lightspark_crypto_5548_Mnemonic_random(_status)
                 },
             )
 
         fun `fromEntropy`(`entropy`: List<UByte>): Mnemonic =
             Mnemonic(
                 rustCallWithError(LightsparkSignerException) { _status ->
-                    _UniFFILib.INSTANCE.lightspark_crypto_2f27_Mnemonic_from_entropy(FfiConverterSequenceUByte.lower(`entropy`), _status)
+                    _UniFFILib.INSTANCE.lightspark_crypto_5548_Mnemonic_from_entropy(FfiConverterSequenceUByte.lower(`entropy`), _status)
                 },
             )
 
         fun `fromPhrase`(`phrase`: String): Mnemonic =
             Mnemonic(
                 rustCallWithError(LightsparkSignerException) { _status ->
-                    _UniFFILib.INSTANCE.lightspark_crypto_2f27_Mnemonic_from_phrase(FfiConverterString.lower(`phrase`), _status)
+                    _UniFFILib.INSTANCE.lightspark_crypto_5548_Mnemonic_from_phrase(FfiConverterString.lower(`phrase`), _status)
                 },
             )
     }
@@ -1219,7 +1219,7 @@ class Seed(
     constructor(`seed`: List<UByte>) :
         this(
             rustCall { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_Seed_new(FfiConverterSequenceUByte.lower(`seed`), _status)
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_Seed_new(FfiConverterSequenceUByte.lower(`seed`), _status)
             },
         )
 
@@ -1233,14 +1233,14 @@ class Seed(
      */
     protected override fun freeRustArcPtr() {
         rustCall { status ->
-            _UniFFILib.INSTANCE.ffi_lightspark_crypto_2f27_Seed_object_free(this.pointer, status)
+            _UniFFILib.INSTANCE.ffi_lightspark_crypto_5548_Seed_object_free(this.pointer, status)
         }
     }
 
     override fun `asBytes`(): List<UByte> =
         callWithPointer {
             rustCall { _status ->
-                _UniFFILib.INSTANCE.lightspark_crypto_2f27_Seed_as_bytes(it, _status)
+                _UniFFILib.INSTANCE.lightspark_crypto_5548_Seed_as_bytes(it, _status)
             }
         }.let {
             FfiConverterSequenceUByte.lift(it)
@@ -1250,7 +1250,7 @@ class Seed(
         fun `fromMnemonic`(`mnemonic`: Mnemonic): Seed =
             Seed(
                 rustCall { _status ->
-                    _UniFFILib.INSTANCE.lightspark_crypto_2f27_Seed_from_mnemonic(FfiConverterTypeMnemonic.lower(`mnemonic`), _status)
+                    _UniFFILib.INSTANCE.lightspark_crypto_5548_Seed_from_mnemonic(FfiConverterTypeMnemonic.lower(`mnemonic`), _status)
                 },
             )
     }
@@ -1305,41 +1305,41 @@ public object FfiConverterTypeNetwork : FfiConverterRustBuffer<Network> {
     }
 }
 
-sealed class Exception(message: String) : Exception(message) {
+sealed class CryptoException(message: String) : Exception(message) {
     // Each variant is a nested class
     // Flat enums carries a string error message, so no special implementation is necessary.
-    class Secp256k1Exception(message: String) : Exception(message)
+    class Secp256k1Exception(message: String) : CryptoException(message)
 
-    class RustSecp256k1Exception(message: String) : Exception(message)
+    class RustSecp256k1Exception(message: String) : CryptoException(message)
 
-    companion object ErrorHandler : CallStatusErrorHandler<Exception> {
-        override fun lift(error_buf: RustBuffer.ByValue): Exception = FfiConverterTypeError.lift(error_buf)
+    companion object ErrorHandler : CallStatusErrorHandler<CryptoException> {
+        override fun lift(error_buf: RustBuffer.ByValue): CryptoException = FfiConverterTypeCryptoError.lift(error_buf)
     }
 }
 
-public object FfiConverterTypeError : FfiConverterRustBuffer<Exception> {
-    override fun read(buf: ByteBuffer): Exception {
+public object FfiConverterTypeCryptoError : FfiConverterRustBuffer<CryptoException> {
+    override fun read(buf: ByteBuffer): CryptoException {
         return when (buf.getInt()) {
-            1 -> Exception.Secp256k1Exception(FfiConverterString.read(buf))
-            2 -> Exception.RustSecp256k1Exception(FfiConverterString.read(buf))
+            1 -> CryptoException.Secp256k1Exception(FfiConverterString.read(buf))
+            2 -> CryptoException.RustSecp256k1Exception(FfiConverterString.read(buf))
             else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
         }
     }
 
-    override fun allocationSize(value: Exception): Int {
+    override fun allocationSize(value: CryptoException): Int {
         return 4
     }
 
     override fun write(
-        value: Exception,
+        value: CryptoException,
         buf: ByteBuffer,
     ) {
         when (value) {
-            is Exception.Secp256k1Exception -> {
+            is CryptoException.Secp256k1Exception -> {
                 buf.putInt(1)
                 Unit
             }
-            is Exception.RustSecp256k1Exception -> {
+            is CryptoException.RustSecp256k1Exception -> {
                 buf.putInt(2)
                 Unit
             }
@@ -1464,14 +1464,14 @@ public object FfiConverterSequenceUByte : FfiConverterRustBuffer<List<UByte>> {
     }
 }
 
-@Throws(Exception::class)
+@Throws(CryptoException::class)
 fun `signEcdsa`(
     `msg`: List<UByte>,
     `privateKeyBytes`: List<UByte>,
 ): List<UByte> {
     return FfiConverterSequenceUByte.lift(
-        rustCallWithError(Exception) { _status ->
-            _UniFFILib.INSTANCE.lightspark_crypto_2f27_sign_ecdsa(
+        rustCallWithError(CryptoException) { _status ->
+            _UniFFILib.INSTANCE.lightspark_crypto_5548_sign_ecdsa(
                 FfiConverterSequenceUByte.lower(`msg`),
                 FfiConverterSequenceUByte.lower(`privateKeyBytes`),
                 _status,
@@ -1480,15 +1480,15 @@ fun `signEcdsa`(
     )
 }
 
-@Throws(Exception::class)
+@Throws(CryptoException::class)
 fun `verifyEcdsa`(
     `msg`: List<UByte>,
     `signatureBytes`: List<UByte>,
     `publicKeyBytes`: List<UByte>,
 ): Boolean {
     return FfiConverterBoolean.lift(
-        rustCallWithError(Exception) { _status ->
-            _UniFFILib.INSTANCE.lightspark_crypto_2f27_verify_ecdsa(
+        rustCallWithError(CryptoException) { _status ->
+            _UniFFILib.INSTANCE.lightspark_crypto_5548_verify_ecdsa(
                 FfiConverterSequenceUByte.lower(`msg`),
                 FfiConverterSequenceUByte.lower(`signatureBytes`),
                 FfiConverterSequenceUByte.lower(`publicKeyBytes`),
@@ -1498,14 +1498,14 @@ fun `verifyEcdsa`(
     )
 }
 
-@Throws(Exception::class)
+@Throws(CryptoException::class)
 fun `encryptEcies`(
     `msg`: List<UByte>,
     `publicKeyBytes`: List<UByte>,
 ): List<UByte> {
     return FfiConverterSequenceUByte.lift(
-        rustCallWithError(Exception) { _status ->
-            _UniFFILib.INSTANCE.lightspark_crypto_2f27_encrypt_ecies(
+        rustCallWithError(CryptoException) { _status ->
+            _UniFFILib.INSTANCE.lightspark_crypto_5548_encrypt_ecies(
                 FfiConverterSequenceUByte.lower(`msg`),
                 FfiConverterSequenceUByte.lower(`publicKeyBytes`),
                 _status,
@@ -1514,14 +1514,14 @@ fun `encryptEcies`(
     )
 }
 
-@Throws(Exception::class)
+@Throws(CryptoException::class)
 fun `decryptEcies`(
     `cipherText`: List<UByte>,
     `privateKeyBytes`: List<UByte>,
 ): List<UByte> {
     return FfiConverterSequenceUByte.lift(
-        rustCallWithError(Exception) { _status ->
-            _UniFFILib.INSTANCE.lightspark_crypto_2f27_decrypt_ecies(
+        rustCallWithError(CryptoException) { _status ->
+            _UniFFILib.INSTANCE.lightspark_crypto_5548_decrypt_ecies(
                 FfiConverterSequenceUByte.lower(`cipherText`),
                 FfiConverterSequenceUByte.lower(`privateKeyBytes`),
                 _status,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -7,12 +7,12 @@ use ecies::decrypt;
 use ecies::encrypt;
 
 #[derive(Clone, Copy, Debug)]
-pub enum Error {
+pub enum CryptoError {
     Secp256k1Error(bitcoin::secp256k1::Error),
     RustSecp256k1Error(ecies::SecpError),
 }
 
-impl fmt::Display for Error {
+impl fmt::Display for CryptoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Secp256k1Error(err) => write!(f, "Secp256k1 error {}", err),
@@ -21,9 +21,9 @@ impl fmt::Display for Error {
     }
 }
 
-pub fn sign_ecdsa(msg: Vec<u8>, private_key_bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
+pub fn sign_ecdsa(msg: Vec<u8>, private_key_bytes: Vec<u8>) -> Result<Vec<u8>, CryptoError> {
     let secp = Secp256k1::new();
-    let sk = SecretKey::from_slice(&private_key_bytes).map_err(Error::Secp256k1Error)?;
+    let sk = SecretKey::from_slice(&private_key_bytes).map_err(CryptoError::Secp256k1Error)?;
     let msg = Message::from_hashed_data::<sha256::Hash>(&msg);
     let signature = secp.sign_ecdsa(&msg, &sk);
     Ok(signature.serialize_compact().to_vec())
@@ -33,21 +33,21 @@ pub fn verify_ecdsa(
     msg: Vec<u8>,
     signature_bytes: Vec<u8>,
     public_key_bytes: Vec<u8>,
-) -> Result<bool, Error> {
+) -> Result<bool, CryptoError> {
     let secp = Secp256k1::new();
-    let pk = PublicKey::from_slice(&public_key_bytes).map_err(Error::Secp256k1Error)?;
+    let pk = PublicKey::from_slice(&public_key_bytes).map_err(CryptoError::Secp256k1Error)?;
     let msg = Message::from_hashed_data::<sha256::Hash>(&msg);
-    let sig = Signature::from_compact(&signature_bytes).map_err(Error::Secp256k1Error)?;
+    let sig = Signature::from_compact(&signature_bytes).map_err(CryptoError::Secp256k1Error)?;
     let result = secp.verify_ecdsa(&msg, &sig, &pk).is_ok();
     Ok(result)
 }
 
-pub fn encrypt_ecies(msg: Vec<u8>, public_key_bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
-    encrypt(&public_key_bytes, &msg).map_err(Error::RustSecp256k1Error)
+pub fn encrypt_ecies(msg: Vec<u8>, public_key_bytes: Vec<u8>) -> Result<Vec<u8>, CryptoError> {
+    encrypt(&public_key_bytes, &msg).map_err(CryptoError::RustSecp256k1Error)
 }
 
-pub fn decrypt_ecies(cipher_text: Vec<u8>, private_key_bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
-    decrypt(&private_key_bytes, &cipher_text).map_err(Error::RustSecp256k1Error)
+pub fn decrypt_ecies(cipher_text: Vec<u8>, private_key_bytes: Vec<u8>) -> Result<Vec<u8>, CryptoError> {
+    decrypt(&private_key_bytes, &cipher_text).map_err(CryptoError::RustSecp256k1Error)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use crypto::decrypt_ecies;
 use crypto::encrypt_ecies;
 use crypto::sign_ecdsa;
 use crypto::verify_ecdsa;
-use crypto::Error;
+use crypto::CryptoError;
 
 #[cfg(not(target_arch = "wasm32"))]
 use signer::InvoiceSignature;

--- a/src/lightspark_crypto.udl
+++ b/src/lightspark_crypto.udl
@@ -1,19 +1,19 @@
 namespace lightspark_crypto {
-    [Throws=Error]
+    [Throws=CryptoError]
     sequence<u8> sign_ecdsa(sequence<u8> msg, sequence<u8> private_key_bytes);
 
-    [Throws=Error]
+    [Throws=CryptoError]
     boolean verify_ecdsa(sequence<u8> msg, sequence<u8> signature_bytes, sequence<u8> public_key_bytes);
 
-    [Throws=Error]
+    [Throws=CryptoError]
     sequence<u8> encrypt_ecies(sequence<u8> msg, sequence<u8> public_key_bytes);
 
-    [Throws=Error]
+    [Throws=CryptoError]
     sequence<u8> decrypt_ecies(sequence<u8> cipher_text, sequence<u8> private_key_bytes);
 };
 
 [Error]
-enum Error {
+enum CryptoError {
   "Secp256k1Error",
   "RustSecp256k1Error",
 };


### PR DESCRIPTION
This was breaking the generated kotlin because it was being renamed to `Exception` which is a reserved symbol.